### PR TITLE
Added requirement for cython.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     # http://packages.python.org/distribute/setuptools.html#setting-the-zip-safe-flag
     zip_safe=False,
     install_requires=["setuptools"],
-    setup_requires=["setuptools-git"],
+    setup_requires=["setuptools-git", "cython"],
     cmdclass=CMDCLASS,
     ext_modules=cythonize(PYRFC_EXT, annotate=True, language_level="3")
     if BUILD_CYTHON


### PR DESCRIPTION
PyRFC requires cython installed. This sets it up as a requirement for a "priority" install.

To address the requirements for cython.

https://github.com/pypa/pip/issues/5761
